### PR TITLE
fix the bugs related to NameAndVakue

### DIFF
--- a/restlight-common/src/main/java/io/esastack/restlight/core/util/ConverterUtils.java
+++ b/restlight-common/src/main/java/io/esastack/restlight/core/util/ConverterUtils.java
@@ -258,7 +258,7 @@ public final class ConverterUtils {
                                                       Type,
                                                       Function<String, Object>> str2ObjectConverterProvider) {
             final Class<?> elementType = requiredClass.getComponentType();
-            Function<String, Object> elementConverter = str2ObjectConverterProvider.apply(elementType, null);
+            Function<String, Object> elementConverter = str2ObjectConverterProvider.apply(elementType, elementType);
             if (elementConverter == null) {
                 // we don't know how to convert the elements
                 return null;
@@ -336,8 +336,9 @@ public final class ConverterUtils {
                 return null;
             }
 
+            final Class<?> elementType = retrieveElementType(requiredType);
             Function<String, Object> elementConverter =
-                    str2ObjectConverterProvider.apply(retrieveElementType(requiredType), null);
+                    str2ObjectConverterProvider.apply(elementType, elementType);
             if (elementConverter == null) {
                 // we don't know how to convert the elements
                 return null;

--- a/restlight-core/src/main/java/io/esastack/restlight/core/resolver/nav/NameAndStringValueResolver.java
+++ b/restlight-core/src/main/java/io/esastack/restlight/core/resolver/nav/NameAndStringValueResolver.java
@@ -35,10 +35,14 @@ public class NameAndStringValueResolver implements NameAndValueResolver {
                                       BiFunction<String, RequestContext, String> valueExtractor,
                                       NameAndValue<String> nav) {
         Checks.checkNotNull(resolverFactory, "resolverFactory");
-        this.converter = Checks.checkNotNull(resolverFactory.getStringConverter(param.type(),
-                param.genericType(),
-                param), "converter");
         this.valueExtractor = Checks.checkNotNull(valueExtractor, "valueExtractor");
+
+        this.converter = resolverFactory.getStringConverter(param.type(),
+                param.genericType(),
+                param);
+        if (this.converter == null) {
+            throw new IllegalStateException("There is no suitable StringConverter for param(" + param + ").");
+        }
 
         Supplier<String> defaultValue = nav.defaultValue();
         if (defaultValue == null) {

--- a/restlight-core/src/main/java/io/esastack/restlight/core/resolver/nav/NameAndValue.java
+++ b/restlight-core/src/main/java/io/esastack/restlight/core/resolver/nav/NameAndValue.java
@@ -27,6 +27,7 @@ public class NameAndValue<T> {
     private final String name;
     private final boolean required;
     private final Supplier<T> defaultValue;
+    private final boolean isLazy;
 
     public NameAndValue(String name, boolean required) {
         this(name, required, null);
@@ -42,6 +43,7 @@ public class NameAndValue<T> {
                         boolean isLazy) {
         this.name = name;
         this.required = required;
+        this.isLazy = isLazy;
         if (defaultValue == null) {
             this.defaultValue = null;
             return;
@@ -65,6 +67,10 @@ public class NameAndValue<T> {
 
     public Supplier<T> defaultValue() {
         return defaultValue;
+    }
+
+    public boolean isLazy() {
+        return isLazy;
     }
 
     private static class LazyDefaultValue<T> implements Supplier<T> {

--- a/restlight-core/src/main/java/io/esastack/restlight/core/resolver/nav/NameAndValue.java
+++ b/restlight-core/src/main/java/io/esastack/restlight/core/resolver/nav/NameAndValue.java
@@ -52,8 +52,8 @@ public class NameAndValue<T> {
         if (isLazy) {
             this.defaultValue = new LazyDefaultValue<>(defaultValue);
         } else {
-            T defaultValueObj = defaultValue.get();
-            this.defaultValue = () -> defaultValueObj;
+            T loaded = defaultValue.get();
+            this.defaultValue = () -> loaded;
         }
     }
 

--- a/restlight-core/src/main/java/io/esastack/restlight/core/resolver/nav/NameAndValue.java
+++ b/restlight-core/src/main/java/io/esastack/restlight/core/resolver/nav/NameAndValue.java
@@ -50,7 +50,8 @@ public class NameAndValue<T> {
         if (isLazy) {
             this.defaultValue = new LazyDefaultValue<>(defaultValue);
         } else {
-            this.defaultValue = defaultValue;
+            T defaultValueObj = defaultValue.get();
+            this.defaultValue = () -> defaultValueObj;
         }
     }
 

--- a/restlight-core/src/main/java/io/esastack/restlight/core/resolver/nav/NameAndValueResolverAdapter.java
+++ b/restlight-core/src/main/java/io/esastack/restlight/core/resolver/nav/NameAndValueResolverAdapter.java
@@ -77,7 +77,7 @@ public class NameAndValueResolverAdapter implements ParamResolver {
             }
         }
 
-        return new NameAndValue<>(name, nav.required(), defaultValue, false);
+        return new NameAndValue<>(name, nav.required(), defaultValue, nav.isLazy());
     }
 
     private boolean useObjectDefaultValueIfRequired(Param param) {

--- a/restlight-core/src/main/java/io/esastack/restlight/core/resolver/param/AbstractParamResolver.java
+++ b/restlight-core/src/main/java/io/esastack/restlight/core/resolver/param/AbstractParamResolver.java
@@ -72,18 +72,6 @@ public abstract class AbstractParamResolver extends NameAndValueResolverFactory 
     private class SingleMapResolver implements NameAndValueResolver {
         @Override
         public Object resolve(String name, RequestContext ctx) {
-            return ctx.request().paramsMap();
-        }
-
-        @Override
-        public NameAndValue<String> createNameAndValue(Param param) {
-            return AbstractParamResolver.this.createNameAndValue(param);
-        }
-    }
-
-    private class ListMapResolver implements NameAndValueResolver {
-        @Override
-        public Object resolve(String name, RequestContext ctx) {
             Map<String, List<String>> p = ctx.request().paramsMap();
             if (p.isEmpty()) {
                 return Collections.emptyMap();
@@ -95,6 +83,18 @@ public abstract class AbstractParamResolver extends NameAndValueResolverFactory 
                 }
             });
             return m;
+        }
+
+        @Override
+        public NameAndValue<String> createNameAndValue(Param param) {
+            return AbstractParamResolver.this.createNameAndValue(param);
+        }
+    }
+
+    private class ListMapResolver implements NameAndValueResolver {
+        @Override
+        public Object resolve(String name, RequestContext ctx) {
+            return ctx.request().paramsMap();
         }
 
         @Override

--- a/restlight-core/src/main/java/io/esastack/restlight/core/resolver/param/QueryBeanParamResolver.java
+++ b/restlight-core/src/main/java/io/esastack/restlight/core/resolver/param/QueryBeanParamResolver.java
@@ -85,14 +85,7 @@ public class QueryBeanParamResolver extends RequestBeanParamResolver {
 
         @Override
         protected NameAndValue<String> createNameAndValue(Param param) {
-            String name;
-            QueryBean.Name alia = param.getAnnotation(QueryBean.Name.class);
-            if (alia != null && !StringUtils.isEmpty(alia.value())) {
-                name = alia.value();
-            } else {
-                name = param.name();
-            }
-            return new NameAndValue<>(name, false, null);
+            return new NameAndValue<>(extractName(param), false, null);
         }
     }
 }

--- a/restlight-core/src/main/java/io/esastack/restlight/core/resolver/param/QueryBeanParamResolver.java
+++ b/restlight-core/src/main/java/io/esastack/restlight/core/resolver/param/QueryBeanParamResolver.java
@@ -85,7 +85,7 @@ public class QueryBeanParamResolver extends RequestBeanParamResolver {
 
         @Override
         protected NameAndValue<String> createNameAndValue(Param param) {
-            return new NameAndValue<>(extractName(param), false, null);
+            return new NameAndValue<>(extractName(param), false);
         }
     }
 }

--- a/restlight-core/src/main/java/io/esastack/restlight/core/spi/impl/DefaultStringConverterFactory.java
+++ b/restlight-core/src/main/java/io/esastack/restlight/core/spi/impl/DefaultStringConverterFactory.java
@@ -28,7 +28,6 @@ public class DefaultStringConverterFactory implements StringConverterFactory {
 
     @Override
     public Optional<StringConverter> createConverter(Class<?> type, Type genericType, Param relatedParam) {
-
         Function<String, Object> converter = null;
         if (genericType != null) {
             converter = ConverterUtils.str2ObjectConverter(genericType);

--- a/restlight-core/src/main/java/io/esastack/restlight/core/spi/impl/DefaultStringConverterFactory.java
+++ b/restlight-core/src/main/java/io/esastack/restlight/core/spi/impl/DefaultStringConverterFactory.java
@@ -28,16 +28,23 @@ public class DefaultStringConverterFactory implements StringConverterFactory {
 
     @Override
     public Optional<StringConverter> createConverter(Class<?> type, Type genericType, Param relatedParam) {
-        Function<String, Object> converter = ConverterUtils.str2ObjectConverter(genericType);
+
+        Function<String, Object> converter = null;
+        if (genericType != null) {
+            converter = ConverterUtils.str2ObjectConverter(genericType);
+        } else if (type != null) {
+            converter = ConverterUtils.str2ObjectConverter(type);
+        }
 
         if (converter == null) {
             return Optional.empty();
         }
 
+        Function<String, Object> finalConverter = converter;
         return Optional.of(new StringConverter() {
             @Override
             public Object fromString(String value) {
-                return converter.apply(value);
+                return finalConverter.apply(value);
             }
 
             @Override

--- a/restlight-ext/restlight-ext-multipart/src/main/java/io/esastack/restlight/ext/multipart/spi/MultipartFileParamResolver.java
+++ b/restlight-ext/restlight-ext-multipart/src/main/java/io/esastack/restlight/ext/multipart/spi/MultipartFileParamResolver.java
@@ -50,7 +50,7 @@ public class MultipartFileParamResolver extends AbstractMultipartParamResolver {
     private NameAndValue<Object> createNameAndValue(Param param) {
         UploadFile uploadFile = param.getAnnotation(UploadFile.class);
         assert uploadFile != null;
-        return new NameAndValue<>(uploadFile.value(), uploadFile.required(), null);
+        return new NameAndValue<>(uploadFile.value(), uploadFile.required());
     }
 
     private List<MultipartFile> extractFiles(String name, RequestContext ctx) {


### PR DESCRIPTION
1. fix the bug that `isLazy` does not take effect in `NameAndValue`
2. fix the bug that `SingleMapResolver` and `ListMapResolver` are reversed in AbstractParamResolver
3. throw an `exception` with more details when `StringConverter` is null