### PR TITLE
optimize performance

### DIFF
--- a/restlight-core/src/main/java/io/esastack/restlight/core/resolver/HttpEntityImpl.java
+++ b/restlight-core/src/main/java/io/esastack/restlight/core/resolver/HttpEntityImpl.java
@@ -16,6 +16,7 @@
 package io.esastack.restlight.core.resolver;
 
 import io.esastack.commons.net.http.MediaType;
+import io.esastack.restlight.core.util.LazyValue;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
@@ -25,9 +26,9 @@ import java.lang.reflect.Type;
  */
 public class HttpEntityImpl implements HttpEntity {
 
-    Class<?> type;
-    Type genericType;
-    Annotation[] annotations;
+    LazyValue<Class<?>> type;
+    LazyValue<Type> genericType;
+    LazyValue<Annotation[]> annotations;
 
     private MediaType mediaType;
 
@@ -37,17 +38,17 @@ public class HttpEntityImpl implements HttpEntity {
 
     @Override
     public Class<?> type() {
-        return type;
+        return type == null ? null : type.get();
     }
 
     @Override
     public Type genericType() {
-        return genericType;
+        return genericType == null ? null : genericType.get();
     }
 
     @Override
     public Annotation[] annotations() {
-        return annotations;
+        return annotations == null ? null : annotations.get();
     }
 
     @Override
@@ -57,17 +58,17 @@ public class HttpEntityImpl implements HttpEntity {
 
     @Override
     public void type(Class<?> type) {
-        this.type = type;
+        this.type = new LazyValue<>(() -> type);
     }
 
     @Override
     public void genericType(Type genericType) {
-        this.genericType = genericType;
+        this.genericType = new LazyValue<>(() -> genericType);
     }
 
     @Override
     public void annotations(Annotation[] annotations) {
-        this.annotations = annotations;
+        this.annotations = new LazyValue<>(() -> annotations);
     }
 
     @Override
@@ -78,8 +79,8 @@ public class HttpEntityImpl implements HttpEntity {
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder("HttpEntityImpl{");
-        sb.append("type=").append(type);
-        sb.append(", genericType=").append(genericType);
+        sb.append("type=").append(type());
+        sb.append(", genericType=").append(genericType());
         sb.append(", mediaType=").append(mediaType);
         sb.append('}');
         return sb.toString();

--- a/restlight-core/src/main/java/io/esastack/restlight/core/resolver/RequestEntityImpl.java
+++ b/restlight-core/src/main/java/io/esastack/restlight/core/resolver/RequestEntityImpl.java
@@ -20,6 +20,7 @@ import esa.commons.io.IOUtils;
 import io.esastack.commons.net.buffer.Buffer;
 import io.esastack.commons.net.buffer.BufferUtil;
 import io.esastack.restlight.core.method.Param;
+import io.esastack.restlight.core.util.LazyValue;
 import io.esastack.restlight.server.context.RequestContext;
 import io.esastack.restlight.server.core.HttpInputStream;
 import io.esastack.restlight.server.core.HttpRequest;
@@ -41,9 +42,9 @@ public class RequestEntityImpl extends HttpEntityImpl implements RequestEntity {
         Checks.checkNotNull(param, "param");
         Checks.checkNotNull(context, "context");
         this.request = context.request();
-        this.type = param.type();
-        this.genericType = param.genericType();
-        this.annotations = param.annotations();
+        this.type = new LazyValue<>(param::type);
+        this.genericType = new LazyValue<>(param::genericType);
+        this.annotations = new LazyValue<>(param::annotations);
         context.response().onEnd(rsp -> this.safeRelease());
     }
 

--- a/restlight-core/src/main/java/io/esastack/restlight/core/resolver/ResponseEntityChannelImpl.java
+++ b/restlight-core/src/main/java/io/esastack/restlight/core/resolver/ResponseEntityChannelImpl.java
@@ -45,8 +45,12 @@ public class ResponseEntityChannelImpl implements ResponseEntityChannel {
 
     @Override
     public void writeThenEnd(byte[] data) {
-        content.write(data);
-        content.end();
+        if (data == null) {
+            end();
+            return;
+        }
+
+        content.writeThenEnd(data);
     }
 
     @Override
@@ -55,8 +59,7 @@ public class ResponseEntityChannelImpl implements ResponseEntityChannel {
             end();
             return;
         }
-        write(buffer);
-        end();
+        content.writeThenEnd(buffer);
     }
 
     @Override

--- a/restlight-core/src/main/java/io/esastack/restlight/core/resolver/ResponseEntityImpl.java
+++ b/restlight-core/src/main/java/io/esastack/restlight/core/resolver/ResponseEntityImpl.java
@@ -19,6 +19,7 @@ import esa.commons.Checks;
 import esa.commons.ClassUtils;
 import io.esastack.commons.net.http.MediaType;
 import io.esastack.restlight.core.method.HandlerMethod;
+import io.esastack.restlight.core.util.LazyValue;
 import io.esastack.restlight.server.core.HttpResponse;
 
 public class ResponseEntityImpl extends HttpEntityImpl implements ResponseEntity {
@@ -29,9 +30,14 @@ public class ResponseEntityImpl extends HttpEntityImpl implements ResponseEntity
         super(mediaType);
         Checks.checkNotNull(response, "response");
         this.response = response;
-        this.type = handler == null ? ClassUtils.getUserType(response.entity()) : handler.method().getReturnType();
-        this.genericType = handler == null ? null : handler.method().getGenericReturnType();
-        this.annotations = handler == null ? null : handler.method().getAnnotations();
+        this.type = handler == null ? new LazyValue<>(() -> ClassUtils.getUserType(response.entity())) :
+                new LazyValue<>(() -> handler.method().getReturnType());
+
+        this.genericType = handler == null ? null :
+                new LazyValue<>(() -> handler.method().getGenericReturnType());
+
+        this.annotations = handler == null ? null :
+                new LazyValue<>(() -> handler.method().getAnnotations());
     }
 
     @Override

--- a/restlight-core/src/main/java/io/esastack/restlight/core/resolver/nav/NameAndValue.java
+++ b/restlight-core/src/main/java/io/esastack/restlight/core/resolver/nav/NameAndValue.java
@@ -15,10 +15,9 @@
  */
 package io.esastack.restlight.core.resolver.nav;
 
-import esa.commons.Checks;
 import esa.commons.annotation.Internal;
+import io.esastack.restlight.core.util.LazyValue;
 
-import java.util.Optional;
 import java.util.function.Supplier;
 
 @Internal
@@ -50,7 +49,7 @@ public class NameAndValue<T> {
         }
 
         if (isLazy) {
-            this.defaultValue = new LazyDefaultValue<>(defaultValue);
+            this.defaultValue = new LazyValue<>(defaultValue);
         } else {
             T loaded = defaultValue.get();
             this.defaultValue = () -> loaded;
@@ -71,43 +70,6 @@ public class NameAndValue<T> {
 
     public boolean isLazy() {
         return isLazy;
-    }
-
-    private static class LazyDefaultValue<T> implements Supplier<T> {
-
-        private final Supplier<T> supplier;
-        /**
-         * Because the value loaded by supplier may be null,so there use {@link Optional} to declare whether
-         * the value had been loaded
-         */
-        @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-        private volatile Optional<T> loaded;
-
-        private LazyDefaultValue(Supplier<T> supplier) {
-            this.supplier = Checks.checkNotNull(supplier, "supplier");
-        }
-
-        @Override
-        public T get() {
-            if (loaded != null) {
-                return getLoaded();
-            }
-            synchronized (this) {
-                if (loaded != null) {
-                    return getLoaded();
-                }
-                loaded = Optional.ofNullable(supplier.get());
-                return getLoaded();
-            }
-        }
-
-        private T getLoaded() {
-            if (loaded == Optional.empty()) {
-                return null;
-            } else {
-                return loaded.orElse(null);
-            }
-        }
     }
 
 }

--- a/restlight-core/src/main/java/io/esastack/restlight/core/util/LazyValue.java
+++ b/restlight-core/src/main/java/io/esastack/restlight/core/util/LazyValue.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022 OPPO ESA Stack Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.esastack.restlight.core.util;
+
+import esa.commons.Checks;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+public class LazyValue<T> implements Supplier<T> {
+
+    private final Supplier<T> supplier;
+    /**
+     * Because the value loaded by supplier may be null,so there use {@link Optional} to declare whether
+     * the value had been loaded
+     */
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    private volatile Optional<T> loaded;
+
+    public LazyValue(Supplier<T> supplier) {
+        this.supplier = Checks.checkNotNull(supplier, "supplier");
+    }
+
+    @Override
+    public T get() {
+        if (loaded != null) {
+            return getLoaded();
+        }
+        synchronized (this) {
+            if (loaded != null) {
+                return getLoaded();
+            }
+            loaded = Optional.ofNullable(supplier.get());
+            return getLoaded();
+        }
+    }
+
+    private T getLoaded() {
+        if (loaded == Optional.empty()) {
+            return null;
+        } else {
+            return loaded.orElse(null);
+        }
+    }
+}

--- a/restlight-core/src/main/java/io/esastack/restlight/server/bootstrap/ResponseContent.java
+++ b/restlight-core/src/main/java/io/esastack/restlight/server/bootstrap/ResponseContent.java
@@ -31,11 +31,25 @@ public interface ResponseContent {
     void write(byte[] data);
 
     /**
+     * Sends the {@code data} to remote endpoint and end current request.
+     *
+     * @param data data
+     */
+    void writeThenEnd(byte[] data);
+
+    /**
      * Send the given {@code buffer} to remote endpoint.
      *
      * @param buffer buffer
      */
     void write(Buffer buffer);
+
+    /**
+     * Sends the {@code buffer} to remote endpoint and end current request.
+     *
+     * @param buffer data
+     */
+    void writeThenEnd(Buffer buffer);
 
     /**
      * Sends the {@code file} to remote endpoint and end current request.

--- a/restlight-core/src/main/java/io/esastack/restlight/server/bootstrap/ResponseContentImpl.java
+++ b/restlight-core/src/main/java/io/esastack/restlight/server/bootstrap/ResponseContentImpl.java
@@ -39,6 +39,11 @@ public class ResponseContentImpl implements ResponseContent {
     }
 
     @Override
+    public void writeThenEnd(byte[] data) {
+        response.end(data);
+    }
+
+    @Override
     public void write(Buffer buffer) {
         if (buffer == null) {
             return;
@@ -51,6 +56,21 @@ public class ResponseContentImpl implements ResponseContent {
         byte[] data = new byte[buffer.readableBytes()];
         buffer.readBytes(data);
         write(data);
+    }
+
+    @Override
+    public void writeThenEnd(Buffer buffer) {
+        if (buffer == null) {
+            return;
+        }
+        Object unwrap = BufferUtil.unwrap(buffer);
+        if (unwrap instanceof ByteBuf) {
+            response.end((ByteBuf) unwrap);
+            return;
+        }
+        byte[] data = new byte[buffer.readableBytes()];
+        buffer.readBytes(data);
+        writeThenEnd(data);
     }
 
     @Override

--- a/restlight-core/src/main/java/io/esastack/restlight/server/mock/MockResponseContent.java
+++ b/restlight-core/src/main/java/io/esastack/restlight/server/mock/MockResponseContent.java
@@ -60,6 +60,12 @@ public class MockResponseContent implements ResponseContent {
     }
 
     @Override
+    public void writeThenEnd(byte[] data) {
+        write(data);
+        ensureEndExclusively(true);
+    }
+
+    @Override
     public void write(Buffer buffer) {
         if (buffer == null) {
             return;
@@ -75,6 +81,12 @@ public class MockResponseContent implements ResponseContent {
             // write is kept in order which needs some means to ensure the memory visibility.
             COMMITTED_UPDATER.lazySet(this, IDLE);
         }
+    }
+
+    @Override
+    public void writeThenEnd(Buffer buffer) {
+        write(buffer);
+        ensureEndExclusively(true);
     }
 
     @Override


### PR DESCRIPTION
1. combine the `write()` and `end()` into writeThenEnd() to reduce the number of system call named write
2. change the acquisition of annotations to lazy loading
3. buildInvoker is called only once when handlerMethod is singleton