### PR TITLE
Fix the  customize `MessageBodyReader` and `MessageBodyWriter` doesn't work.

### DIFF
--- a/restlight-jaxrs-provider/src/main/java/io/esastack/restlight/jaxrs/adapter/MessageBodyReaderAdapter.java
+++ b/restlight-jaxrs-provider/src/main/java/io/esastack/restlight/jaxrs/adapter/MessageBodyReaderAdapter.java
@@ -66,7 +66,7 @@ public class MessageBodyReaderAdapter<T> implements RequestEntityResolverAdapter
 
     @Override
     public int getOrder() {
-        return Ordered.LOWEST_PRECEDENCE;
+        return Ordered.HIGHEST_PRECEDENCE;
     }
 
 }

--- a/restlight-jaxrs-provider/src/main/java/io/esastack/restlight/jaxrs/adapter/MessageBodyReaderAdapter.java
+++ b/restlight-jaxrs-provider/src/main/java/io/esastack/restlight/jaxrs/adapter/MessageBodyReaderAdapter.java
@@ -62,5 +62,11 @@ public class MessageBodyReaderAdapter<T> implements RequestEntityResolverAdapter
         // bind this to param at the starting time.
         return true;
     }
+
+    @Override
+    public int getOrder() {
+        return 90;
+    }
+
 }
 

--- a/restlight-jaxrs-provider/src/main/java/io/esastack/restlight/jaxrs/adapter/MessageBodyReaderAdapter.java
+++ b/restlight-jaxrs-provider/src/main/java/io/esastack/restlight/jaxrs/adapter/MessageBodyReaderAdapter.java
@@ -20,7 +20,6 @@ import esa.commons.Result;
 import io.esastack.restlight.core.method.Param;
 import io.esastack.restlight.core.resolver.RequestEntity;
 import io.esastack.restlight.core.resolver.RequestEntityResolverAdapter;
-import io.esastack.restlight.core.util.Ordered;
 import io.esastack.restlight.jaxrs.impl.core.ModifiableMultivaluedMap;
 import io.esastack.restlight.jaxrs.util.MediaTypeUtils;
 import io.esastack.restlight.server.context.RequestContext;
@@ -63,11 +62,5 @@ public class MessageBodyReaderAdapter<T> implements RequestEntityResolverAdapter
         // bind this to param at the starting time.
         return true;
     }
-
-    @Override
-    public int getOrder() {
-        return Ordered.HIGHEST_PRECEDENCE;
-    }
-
 }
 

--- a/restlight-jaxrs-provider/src/main/java/io/esastack/restlight/jaxrs/adapter/MessageBodyWriterAdapter.java
+++ b/restlight-jaxrs-provider/src/main/java/io/esastack/restlight/jaxrs/adapter/MessageBodyWriterAdapter.java
@@ -83,5 +83,11 @@ public class MessageBodyWriterAdapter<T> implements ResponseEntityResolverAdapte
     public boolean alsoApplyWhenMissingHandler() {
         return true;
     }
+
+    @Override
+    public int getOrder() {
+        return 90;
+    }
+
 }
 

--- a/restlight-jaxrs-provider/src/main/java/io/esastack/restlight/jaxrs/adapter/MessageBodyWriterAdapter.java
+++ b/restlight-jaxrs-provider/src/main/java/io/esastack/restlight/jaxrs/adapter/MessageBodyWriterAdapter.java
@@ -45,6 +45,9 @@ public class MessageBodyWriterAdapter<T> implements ResponseEntityResolverAdapte
     public Result<Void, Void> writeTo(ResponseEntity entity,
                                       ResponseEntityChannel channel,
                                       RequestContext context) throws Exception {
+        if (entity.response().entity() == null) {
+            return Result.err();
+        }
         Class<?> type = entity.type();
         if (type == null) {
             entity.type(ClassUtils.getUserType(entity.response().entity()));

--- a/restlight-jaxrs-provider/src/main/java/io/esastack/restlight/jaxrs/adapter/MessageBodyWriterAdapter.java
+++ b/restlight-jaxrs-provider/src/main/java/io/esastack/restlight/jaxrs/adapter/MessageBodyWriterAdapter.java
@@ -22,7 +22,6 @@ import io.esastack.restlight.core.method.HandlerMethod;
 import io.esastack.restlight.core.resolver.ResponseEntity;
 import io.esastack.restlight.core.resolver.ResponseEntityChannel;
 import io.esastack.restlight.core.resolver.ResponseEntityResolverAdapter;
-import io.esastack.restlight.core.util.Ordered;
 import io.esastack.restlight.core.util.ResponseEntityUtils;
 import io.esastack.restlight.jaxrs.util.JaxrsUtils;
 import io.esastack.restlight.jaxrs.util.MediaTypeUtils;
@@ -81,11 +80,5 @@ public class MessageBodyWriterAdapter<T> implements ResponseEntityResolverAdapte
     public boolean alsoApplyWhenMissingHandler() {
         return true;
     }
-
-    @Override
-    public int getOrder() {
-        return Ordered.HIGHEST_PRECEDENCE;
-    }
-
 }
 

--- a/restlight-jaxrs-provider/src/main/java/io/esastack/restlight/jaxrs/adapter/MessageBodyWriterAdapter.java
+++ b/restlight-jaxrs-provider/src/main/java/io/esastack/restlight/jaxrs/adapter/MessageBodyWriterAdapter.java
@@ -46,9 +46,6 @@ public class MessageBodyWriterAdapter<T> implements ResponseEntityResolverAdapte
     public Result<Void, Void> writeTo(ResponseEntity entity,
                                       ResponseEntityChannel channel,
                                       RequestContext context) throws Exception {
-        if (entity.response().entity() == null) {
-            return Result.err();
-        }
         Class<?> type = entity.type();
         if (type == null) {
             entity.type(ClassUtils.getUserType(entity.response().entity()));
@@ -87,7 +84,7 @@ public class MessageBodyWriterAdapter<T> implements ResponseEntityResolverAdapte
 
     @Override
     public int getOrder() {
-        return Ordered.LOWEST_PRECEDENCE;
+        return Ordered.HIGHEST_PRECEDENCE;
     }
 
 }


### PR DESCRIPTION
Motivation:

<!-- Explain here the context, and why you're making that change.
What is the problem you're trying to solve.
-->
1.the customize `MessageBodyReader` and `MessageBodyWriter` doesn't work.
2.when the return value is null, the `MessageBodyWriter`  doesn't work.

Modification:

<!-- Describe the modifications you've done. -->
1.change the `MessageBodyReaderAdapter`'s order to `HIGHEST_PRECEDENCE`.
2.change the `MessageBodyWriterAdapter`'s order to `HIGHEST_PRECEDENCE` and remove the null check logic in it.

Result:

<!-- Fixes #<GitHub issue number>.

If there is no issue then describe the changes introduced by this PR.
-->
Fixes  #155