### PR TITLE
Fix the `@RequestBean` and `@QueryBean` sometime do not work.

### DIFF
--- a/restlight-core/src/main/java/io/esastack/restlight/core/resolver/param/RequestBeanParamResolver.java
+++ b/restlight-core/src/main/java/io/esastack/restlight/core/resolver/param/RequestBeanParamResolver.java
@@ -48,7 +48,7 @@ import java.util.stream.Collectors;
  */
 public class RequestBeanParamResolver implements ParamResolverFactory {
 
-    private static final Map<Class<?>, ParamResolver> META_CACHE = new ConcurrentHashMap<>(16);
+    protected final Map<Class<?>, ParamResolver> metaCache = new ConcurrentHashMap<>(16);
     private final DeployContext ctx;
 
     public RequestBeanParamResolver(DeployContext ctx) {
@@ -70,10 +70,10 @@ public class RequestBeanParamResolver implements ParamResolverFactory {
         Class<?> type = param.type();
         // instantiate target object by unsafe
 
-        ParamResolver resolver = META_CACHE.get(type);
+        ParamResolver resolver = metaCache.get(type);
         if (resolver == null) {
             // no need to check the previous value
-            META_CACHE.putIfAbsent(type, resolver = new Resolver(newTypeMeta(type,
+            metaCache.putIfAbsent(type, resolver = new Resolver(newTypeMeta(type,
                     converters,
                     ctx.resolverFactory().orElse(null))));
         }

--- a/restlight-core/src/main/java/io/esastack/restlight/core/spi/impl/DefaultStringConverterFactory.java
+++ b/restlight-core/src/main/java/io/esastack/restlight/core/spi/impl/DefaultStringConverterFactory.java
@@ -36,15 +36,16 @@ public class DefaultStringConverterFactory implements StringConverterFactory {
         } else {
             converter = ConverterUtils.str2ObjectConverter(key.type());
         }
-        if (converter == null) {
-            throw new IllegalArgumentException("There is no suitable StringConverter for class(" + key.type() + "),"
-                    + "It should have a constructor that accepts a single String argument or "
-                    + "have a static method named valueOf() or fromString() that accepts a single String argument.");
-        }
 
         return Optional.of(new StringConverter() {
             @Override
             public Object fromString(String value) {
+                if (converter == null) {
+                    throw new IllegalArgumentException("There is no suitable StringConverter for class(" + key.type() + "),"
+                            + "It should have a constructor that accepts a single String argument or "
+                            + "have a static method named valueOf() or fromString() that accepts a single String argument.");
+                }
+
                 return converter.apply(value);
             }
 

--- a/restlight-core/src/main/java/io/esastack/restlight/core/spi/impl/DefaultStringConverterFactory.java
+++ b/restlight-core/src/main/java/io/esastack/restlight/core/spi/impl/DefaultStringConverterFactory.java
@@ -41,9 +41,10 @@ public class DefaultStringConverterFactory implements StringConverterFactory {
             @Override
             public Object fromString(String value) {
                 if (converter == null) {
-                    throw new IllegalArgumentException("There is no suitable StringConverter for class(" + key.type() + "),"
-                            + "It should have a constructor that accepts a single String argument or "
-                            + "have a static method named valueOf() or fromString() that accepts a single String argument.");
+                    throw new IllegalArgumentException("There is no suitable StringConverter for class(" +
+                            key.type() + "),It should have a constructor that accepts a single String argument" +
+                            " or have a static method named valueOf() or fromString() that accepts a " +
+                            "single String argument.");
                 }
 
                 return converter.apply(value);

--- a/restlight-integration-test/springmvc-test/src/main/java/io/esastack/restlight/integration/springmvc/cases/annotation/CustomFieldParam.java
+++ b/restlight-integration-test/springmvc-test/src/main/java/io/esastack/restlight/integration/springmvc/cases/annotation/CustomFieldParam.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022 OPPO ESA Stack Project
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.esastack.restlight.integration.springmvc.cases.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface CustomFieldParam {
+}

--- a/restlight-integration-test/springmvc-test/src/main/java/io/esastack/restlight/integration/springmvc/cases/config/ResolverConfig.java
+++ b/restlight-integration-test/springmvc-test/src/main/java/io/esastack/restlight/integration/springmvc/cases/config/ResolverConfig.java
@@ -29,11 +29,12 @@ import io.esastack.restlight.core.resolver.StringConverterProvider;
 import io.esastack.restlight.core.resolver.rspentity.AbstractResponseEntityResolver;
 import io.esastack.restlight.core.serialize.HttpRequestSerializer;
 import io.esastack.restlight.core.serialize.HttpResponseSerializer;
+import io.esastack.restlight.integration.springmvc.cases.annotation.CustomFieldParam;
 import io.esastack.restlight.integration.springmvc.cases.annotation.CustomRequestBean;
-import io.esastack.restlight.server.context.RequestContext;
 import io.esastack.restlight.integration.springmvc.cases.annotation.CustomRequestBody;
 import io.esastack.restlight.integration.springmvc.cases.annotation.CustomResponseBody;
 import io.esastack.restlight.integration.springmvc.entity.UserData;
+import io.esastack.restlight.server.context.RequestContext;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -123,6 +124,22 @@ public class ResolverConfig {
             @Override
             public boolean supports(HandlerMethod method) {
                 return method.hasMethodAnnotation(CustomResponseBody.class, true);
+            }
+        };
+    }
+
+    @Bean
+    public ParamResolverFactory customParamResolverFactory() {
+        return new ParamResolverFactory() {
+            @Override
+            public ParamResolver createResolver(Param param, StringConverterProvider converters,
+                                                List<? extends HttpRequestSerializer> serializers) {
+                return context -> context.request().getParam("name");
+            }
+
+            @Override
+            public boolean supports(Param param) {
+                return param.hasAnnotation(CustomFieldParam.class);
             }
         };
     }

--- a/restlight-integration-test/springmvc-test/src/main/java/io/esastack/restlight/integration/springmvc/cases/controller/AnnotationController.java
+++ b/restlight-integration-test/springmvc-test/src/main/java/io/esastack/restlight/integration/springmvc/cases/controller/AnnotationController.java
@@ -111,4 +111,9 @@ public class AnnotationController {
     public String customResponseBody(@RequestParam String name) {
         return name;
     }
+
+    @GetMapping("get/param/wrong")
+    public UserData paramWrong(@RequestParam UserData user) {
+        return user;
+    }
 }

--- a/restlight-integration-test/springmvc-test/src/main/java/io/esastack/restlight/integration/springmvc/entity/UserData.java
+++ b/restlight-integration-test/springmvc-test/src/main/java/io/esastack/restlight/integration/springmvc/entity/UserData.java
@@ -13,11 +13,14 @@
 
 package io.esastack.restlight.integration.springmvc.entity;
 
+import io.esastack.restlight.integration.springmvc.cases.annotation.CustomFieldParam;
+
 import java.math.BigDecimal;
 import java.util.Date;
 
 public class UserData {
 
+    @CustomFieldParam
     private String name;
 
     private Integer age;

--- a/restlight-integration-test/springmvc-test/src/main/java/io/esastack/restlight/integration/springmvc/test/AnnotationTest.java
+++ b/restlight-integration-test/springmvc-test/src/main/java/io/esastack/restlight/integration/springmvc/test/AnnotationTest.java
@@ -138,4 +138,11 @@ public class AnnotationTest extends BaseIntegrationTest {
         UserData user = response.bodyToEntity(UserData.class);
         Assert.assertEquals("test", user.getName());
     }
+
+    @Test
+    public void testParamWrong() throws Exception {
+        RestResponseBase response = restClient.get(domain + "/annotation/get/param/wrong")
+                .addParam("user", "").execute().toCompletableFuture().get();
+        Assert.assertEquals(HttpStatus.INTERNAL_SERVER_ERROR.code(), response.status());
+    }
 }

--- a/restlight-integration-test/springmvc-test/src/main/java/io/esastack/restlight/integration/springmvc/test/AwareTest.java
+++ b/restlight-integration-test/springmvc-test/src/main/java/io/esastack/restlight/integration/springmvc/test/AwareTest.java
@@ -14,7 +14,6 @@
 package io.esastack.restlight.integration.springmvc.test;
 
 import io.esastack.restclient.RestResponseBase;
-import io.netty.channel.nio.NioEventLoopGroup;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -33,7 +32,7 @@ public class AwareTest extends BaseIntegrationTest {
     public void testIoAware() throws Exception {
         RestResponseBase response = restClient.get(domain + "/aware/get/io").execute()
                 .toCompletableFuture().get();
-        Assert.assertEquals(NioEventLoopGroup.class.getName(), response.bodyToEntity(String.class));
+        Assert.assertTrue(response.bodyToEntity(String.class).contains("EventLoopGroup"));
     }
 
     @Test

--- a/restlight-jaxrs-provider/src/test/java/io/esastack/restlight/jaxrs/adapter/MessageBodyReaderAdapterTest.java
+++ b/restlight-jaxrs-provider/src/test/java/io/esastack/restlight/jaxrs/adapter/MessageBodyReaderAdapterTest.java
@@ -48,7 +48,7 @@ class MessageBodyReaderAdapterTest {
     void testBasic() {
         assertThrows(NullPointerException.class, () -> new MessageBodyWriterAdapter<>(null));
         MessageBodyReaderAdapter<?> adapter = new MessageBodyReaderAdapter<>(mock(Providers.class));
-        assertEquals(Ordered.LOWEST_PRECEDENCE, adapter.getOrder());
+        assertEquals(90, adapter.getOrder());
         assertTrue(adapter.supports(mock(Param.class)));
     }
 

--- a/restlight-jaxrs-provider/src/test/java/io/esastack/restlight/jaxrs/adapter/MessageBodyWriterAdapterTest.java
+++ b/restlight-jaxrs-provider/src/test/java/io/esastack/restlight/jaxrs/adapter/MessageBodyWriterAdapterTest.java
@@ -65,7 +65,7 @@ class MessageBodyWriterAdapterTest {
 
         final Providers providers = mock(Providers.class);
         final MessageBodyWriterAdapter<?> adapter = new MessageBodyWriterAdapter<>(providers);
-        assertEquals(Ordered.LOWEST_PRECEDENCE, adapter.getOrder());
+        assertEquals(90, adapter.getOrder());
 
         final HttpResponse response = mock(HttpResponse.class);
         final ResponseEntity entity = mock(ResponseEntity.class);


### PR DESCRIPTION
Motivation:

<!-- Explain here the context, and why you're making that change.
What is the problem you're trying to solve.
-->
- fix the `@RequestBean` and `@QueryBean` sometime do not work.
- fix the `@RequestParam` to pojo throws NPE.

Modification:

<!-- Describe the modifications you've done. -->
- the cache in `RequestBeanParamReslover` and `QueryBeanParamReslover` don't use the same
- correct the test case of `@RequestBean`
-throw correct exception when no converter. 

Result:

<!-- Fixes #<GitHub issue number>.

If there is no issue then describe the changes introduced by this PR.
-->
Fixes #144 
Fixes #141 
