### PR TITLE
upgrade esa-commons and esa-httpserver

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -3,7 +3,7 @@ name: github pages
 on:
   push:
     branches:
-    - 1.0  # Set a branch to deploy
+    - main  # Set a branch to deploy
 jobs:
   deploy:
     runs-on: ubuntu-18.04

--- a/pom.xml
+++ b/pom.xml
@@ -144,10 +144,10 @@
         <encoding>UTF-8</encoding>
         <project.build.sourceEncoding>${encoding}</project.build.sourceEncoding>
         <project.reporting.outputEncoding>${encoding}</project.reporting.outputEncoding>
-        <esa-commons.version>0.2.1-SNAPSHOT</esa-commons.version>
+        <esa-commons.version>0.2.1</esa-commons.version>
         <esa-commons-build.version>1.0</esa-commons-build.version>
         <esa-commons.net.version>0.0.1</esa-commons.net.version>
-        <esa-httpserver.version>0.1.1-SNAPSHOT</esa-httpserver.version>
+        <esa-httpserver.version>0.1.1</esa-httpserver.version>
         <guava.version>29.0-jre</guava.version>
         <spring-boot.version>2.1.2.RELEASE</spring-boot.version>
         <spring-core.version>5.1.4.RELEASE</spring-core.version>

--- a/site/config.toml
+++ b/site/config.toml
@@ -215,7 +215,7 @@ enable = false
 
 # multi-versions
 [[params.versions]]
-  version = "1.0.0-SNAPSHOT(Newest)"
+  version = "1.0.0(Newest)"
   url = "/docs"
 [[params.versions]]
   version = "v0.1.1"


### PR DESCRIPTION
Motivation:

upgrade esa-commons and esa-httpserver

Modification:

- upgrade esa-commons and esa-httpserver
- change branch from 1.0 to main in gh-pages.yaml
- change version 1.0.0-SNAPSHOT to 1.0.0 in config.toml
